### PR TITLE
Put the config file in ~/.fakemenot.config

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Python CLI app to detect if a screenshot of a tweet is genuine. Work in Progress
 ### Setting Up
 
 * Run `python setup.py install` to install requirements. Install script is still a work in progress.
-* Copy `fakemenot/twitter.config` to ~/.fakemenot.config
+* `[ ! -f ~/.fakemenot.config ] && cp fakemenot/twitter.config ~/.fakemenot.config`
 * Go to https://apps.twitter.com/app/new and put your consumer and API keys in `~/.fakemenot.config`
 * Run `fakemenot` after installation. Setup will install it in your path.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Specify the number of tweets to pull from the detected user. Defaults to 100. Re
 
 * `--config/-c`
 
-Specify an alternate configuration file containing your twitter identification and authentication material.  Defaults to ~/.twitter.config
+Specify an alternate configuration file containing your twitter identification and authentication material.  Defaults to ~/.fakemenot.config
 
 ### Image Samples 
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ Python CLI app to detect if a screenshot of a tweet is genuine. Work in Progress
 ### Setting Up
 
 * Run `python setup.py install` to install requirements. Install script is still a work in progress.
-* Run `python fakemenot/app.py` after installation.
-* Go to https://apps.twitter.com/app/new and put your consumer and API keys in `fakemenot/twitter.config`
+* Copy `fakemenot/twitter.config` to ~/.fakemenot.config
+* Go to https://apps.twitter.com/app/new and put your consumer and API keys in `~/.fakemenot.config`
+* Run `fakemenot` after installation. Setup will install it in your path.
 
 ### Limitations
 * Since it does OCR on the image, detection rate will vary on the quality of the screenshot.
@@ -27,6 +28,10 @@ Path to the screenshot image of tweet. Only works on Desktop screenshots.
 
 Specify the number of tweets to pull from the detected user. Defaults to 100. Retweets are not pulled and does not affect the limit.
 
+
+* `--config/-c`
+
+Specify an alternate configuration file containing your twitter identification and authentication material.  Defaults to ~/.twitter.config
 
 ### Image Samples 
 

--- a/fakemenot/__init__.py
+++ b/fakemenot/__init__.py
@@ -21,7 +21,7 @@ from PIL import Image, ImageEnhance, ImageFilter
 Please don't hate me for doing this right after import
 (and for this ugly multiline comment)'''
 parser = argparse.ArgumentParser(description='Process images')
-parser.add_argument('--image', '-i', help='Twitter screenshot image') # , required=True)
+parser.add_argument('--image', '-i', help='Twitter screenshot image', required=True)
 parser.add_argument('--limit', '-l', help='Limit tweets pulled', default=100)
 parser.add_argument('--config', '-c', help='Path to twitter config (default: ~/.fakemenot.config)', default="~/.fakemenot.config")
 

--- a/fakemenot/__init__.py
+++ b/fakemenot/__init__.py
@@ -9,6 +9,8 @@ Tested on Arch Linux - Rolling
 '''
 
 import argparse
+import os
+import sys
 import pytesseract
 import configparser
 from TwitterSearch import *
@@ -19,13 +21,25 @@ from PIL import Image, ImageEnhance, ImageFilter
 Please don't hate me for doing this right after import
 (and for this ugly multiline comment)'''
 parser = argparse.ArgumentParser(description='Process images')
-parser.add_argument('--image', '-i', help='Twitter screenshot image', required=True)
+parser.add_argument('--image', '-i', help='Twitter screenshot image') # , required=True)
 parser.add_argument('--limit', '-l', help='Limit tweets pulled', default=100)
+parser.add_argument('--config', '-c', help='Path to twitter config (default: ~/.fakemenot.config)', default="~/.fakemenot.config")
 
 args = parser.parse_args()
 
+def get_config():
+    config = configparser.RawConfigParser()
+    try:
+        with open(os.path.expanduser(args.config)) as config_file: 
+            config.readfp(config_file)
+    except IOError as ioe:
+        print("Couldn't open the config file {} because {}".format(
+            args.config, ioe))
+        sys.exit(2)
+    return config
 
 def _do_ocr_and_lookup(img_obj):
+    config = get_config()
     limit_of_tweets = int(args.limit)
     # Replace line breaks with a space and split text into an array
     text = pytesseract.image_to_string(img_obj, lang='eng').replace('\n', ' ').split(' ')
@@ -34,9 +48,6 @@ def _do_ocr_and_lookup(img_obj):
             # Since handles cannot have spaces, strip until space
             potential_user = element.split(' ')[0]
             break;
-
-    config = configparser.RawConfigParser()
-    config.readfp(open('twitter.config'))
 
     # Just in case, the dude/dudette using the program puts in ' or " in the config.
     consumer_key = config.get('twitter', 'consumer_key').replace('\'', '').replace('\"', '')


### PR DESCRIPTION
Add a flag specifying an alternative on the command line as well.

I changed the file name from `twitter.config` because in someone's home directory the new name should make it clearer to the user what app the file is related to.