### PR TITLE
Bugfix for failing to recognise tweet when accuracy is 100%

### DIFF
--- a/fakemenot/__init__.py
+++ b/fakemenot/__init__.py
@@ -131,7 +131,7 @@ def _do_ocr_and_lookup(img_obj):
                     ltweet.remove(ele)
             removal_rate = (removed_elements / float(orig_len)) * 100
 
-            if int(removal_rate) in range(75, 100):
+            if int(removal_rate) > 75:
                 found_tweet = True
                 print(colored("[*] It looks like this is a valid tweet",
                               'green'))


### PR DESCRIPTION
As the title says, in case there is a perfect match, it will not catch the case when 100.0 is there, since its not part of the range(75,100).