### PR TITLE
Better exception handling while opening files

### DIFF
--- a/fakemenot/__init__.py
+++ b/fakemenot/__init__.py
@@ -162,8 +162,12 @@ def _do_ocr_and_lookup(img_obj):
 def _blow_up_image():
     try:
         img = Image.open(args.image)
-    except (OSError, IOError):
+    except FileNotFoundError:
         print(colored("[!] I couldn't find a file by that name. Fake you!",
+                      'red'))
+        return False
+    except OSError:
+        print(colored("[!] {} is not an image file!".format(args.image),
                       'red'))
         return False
 


### PR DESCRIPTION

> I couldn't find a file by that name. Fake you!

`fakemenot` always dies by saying the above message, if a file at the given path cannot be found _or_ if the input file is not actually an image file.

Split the exception handler to print the reason respectively.   